### PR TITLE
Ability to pass an existing canvas or context

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Install
 Saves an ndarray as an image with the given format
 
 * `array` is an `ndarray` of pixels.  Assumes that shape is `[rows, columns, channels]`
-* `type` is the type of the image to save.  Currently supported formats:
+* `type` is the type of the image to save or a canvas element or 2d rendering context.  Currently supported formats:
 
   + `"png"` - Portable Network Graphics format
   + `"canvas"` - A canvas element

--- a/save-pixels.js
+++ b/save-pixels.js
@@ -60,6 +60,15 @@ function haderror(err) {
 }
 
 module.exports = function savePixels(array, type) {
+  var canvas, context
+  if (type instanceof CanvasRenderingContext2D) {
+    canvas = type.canvas
+    context = type
+    type = 'CANVAS'
+  } else if (type instanceof HTMLCanvasElement) {
+    canvas = type
+    type = 'CANVAS'
+  }
   switch(type.toUpperCase()) {
     case "PNG":
     case ".PNG":
@@ -73,8 +82,8 @@ module.exports = function savePixels(array, type) {
       return png.pack()
 
     case "CANVAS":
-      var canvas = document.createElement("canvas")
-      var context = canvas.getContext("2d")
+      canvas = canvas || document.createElement("canvas")
+      context = context || canvas.getContext("2d")
       canvas.width = array.shape[1]
       canvas.height = array.shape[0]
       var imageData = context.getImageData(0, 0, canvas.width, canvas.height)


### PR DESCRIPTION
This way if I have an existing canvas or context, I can just save the ndarray to it.

I'm working on a 2d game built on ndarrays. I would like to save the pixels from a ndarray per animation frame to a canvas. Let me know if this method isn't the best way.

Thanks!
