### PR TITLE
Updated `save-pixels` signature to match `get-pixels`. Fixes #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Install
 ### `require("save-pixels")(array, type)`
 Saves an ndarray as an image with the given format
 
-* `array` is an `ndarray` of pixels.  Assumes that shape is `[rows, columns, channels]`
+* `array` is an `ndarray` of pixels.  Assumes that shape is `[width, height, channels]`
 * `type` is the type of the image to save.  Currently supported formats:
 
   + `"png"` - Portable Network Graphics format

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "through": "^2.3.4"
   },
   "devDependencies": {
+    "get-pixels": "~3.0.1",
     "ndarray": "~1.0.0",
-    "get-pixels": "~1.0.1",
     "tap": "~0.4.3",
     "zeros": "0.0.0"
   },

--- a/save-pixels.js
+++ b/save-pixels.js
@@ -7,8 +7,8 @@ function handleData(array, data) {
   var i, j, ptr = 0, c
   if(array.shape.length === 3) {
     if(array.shape[2] === 3) {
-      for(i=0; i<array.shape[0]; ++i) {
-        for(j=0; j<array.shape[1]; ++j) {
+      for(j=0; j<array.shape[1]; ++j) {
+        for(i=0; i<array.shape[0]; ++i) {
           data[ptr++] = array.get(i,j,0)>>>0
           data[ptr++] = array.get(i,j,1)>>>0
           data[ptr++] = array.get(i,j,2)>>>0
@@ -16,8 +16,8 @@ function handleData(array, data) {
         }
       }
     } else if(array.shape[2] === 4) {
-      for(i=0; i<array.shape[0]; ++i) {
-        for(j=0; j<array.shape[1]; ++j) {
+      for(j=0; j<array.shape[1]; ++j) {
+        for(i=0; i<array.shape[0]; ++i) {
           data[ptr++] = array.get(i,j,0)>>>0
           data[ptr++] = array.get(i,j,1)>>>0
           data[ptr++] = array.get(i,j,2)>>>0
@@ -25,8 +25,8 @@ function handleData(array, data) {
         }
       }
     } else if(array.shape[3] === 1) {
-      for(i=0; i<array.shape[0]; ++i) {
-        for(j=0; j<array.shape[1]; ++j) {
+      for(j=0; j<array.shape[1]; ++j) {
+        for(i=0; i<array.shape[0]; ++i) {
           var c = array.get(i,j,0)>>>0
           data[ptr++] = c
           data[ptr++] = c
@@ -38,8 +38,8 @@ function handleData(array, data) {
       return new Error("Incompatible array shape")
     }
   } else if(array.shape.length === 2) {
-    for(i=0; i<array.shape[0]; ++i) {
-      for(j=0; j<array.shape[1]; ++j) {
+    for(j=0; j<array.shape[1]; ++j) {
+      for(i=0; i<array.shape[0]; ++i) {
         var c = array.get(i,j,0)>>>0
         data[ptr++] = c
         data[ptr++] = c
@@ -64,8 +64,8 @@ module.exports = function savePixels(array, type) {
     case "PNG":
     case ".PNG":
       var png = new PNG({
-        width: array.shape[1],
-        height: array.shape[0]
+        width: array.shape[0],
+        height: array.shape[1]
       })
       var data = handleData(array, png.data)
       if (typeof data === "Error") return haderror(data)
@@ -75,8 +75,8 @@ module.exports = function savePixels(array, type) {
     case "CANVAS":
       var canvas = document.createElement("canvas")
       var context = canvas.getContext("2d")
-      canvas.width = array.shape[1]
-      canvas.height = array.shape[0]
+      canvas.width = array.shape[0]
+      canvas.height = array.shape[1]
       var imageData = context.getImageData(0, 0, canvas.width, canvas.height)
       var data = imageData.data
       data = handleData(array, data)


### PR DESCRIPTION
As discussed in #6, it would be ideal to have consistent signatures between `get-pixels` and `save-pixels`. To keep consistency with `Canvas`, we are using `[width, height, channels]` for our `ndarray's`. In this PR:
- Upgrade to `get-pixels@3.0.1` to pickup latest signature
- Updated `README.md` with new `ndarray` signature
- Updated `save-pixels.js` to work with new shape
