### PR TITLE
Added support for GIFs. Fixes #5

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "contentstream": "^1.0.0",
+    "gif-encoder": "~0.4.1",
     "jpeg-js": "0.0.4",
     "pngjs": "~0.4.0-alpha",
     "through": "^2.3.4"

--- a/test/test.js
+++ b/test/test.js
@@ -63,8 +63,12 @@ function testArray(t, array, format, cb) {
           return
         }
         
-        t.equals(array.shape[0], data.shape[0])
-        t.equals(array.shape[1], data.shape[1])
+        var arrayWidth = array.shape.length <= 3 ? array.shape[0] : array.shape[1]
+        var arrayHeight = array.shape.length <= 3 ? array.shape[1] : array.shape[2]
+        var dataWidth = data.shape.length <= 3 ? data.shape[0] : data.shape[1]
+        var dataHeight = data.shape.length <= 3 ? data.shape[1] : data.shape[2]
+        t.equals(arrayWidth, dataWidth)
+        t.equals(arrayHeight, dataHeight)
         
         if(array.shape.length === 2) {
           for(var i=0; i<array.shape[0]; ++i) {
@@ -76,16 +80,32 @@ function testArray(t, array, format, cb) {
               }
             }
           }
+        } else if(array.shape.length === 3) {
+          for(var i=0; i<array.shape[0]; ++i) {
+            for(var j=0; j<array.shape[1]; ++j) {
+              for(var k=0; k<array.shape[2]; ++k) {
+                if(data.shape.length === 3) {
+                  t.equals(array.get(i,j,k), data.get(i,j,k))
+                } else {
+                  t.equals(array.get(i,j,k), data.get(0,i,j,k))
+                }
+              }
+            }
+          }
         } else {
           for(var i=0; i<array.shape[0]; ++i) {
             for(var j=0; j<array.shape[1]; ++j) {
               for(var k=0; k<array.shape[2]; ++k) {
-                t.equals(array.get(i,j,k), data.get(i,j,k))
+                for(var l=0; l<array.shape[3]; ++l) {
+                  t.equals(array.get(i,j,k,l), data.get(i,j,k,l))
+                }
               }
             }
           }
         }
-        fs.unlinkSync("temp." + format)
+        if (!process.env.TEST_DEBUG) {
+          fs.unlinkSync("temp." + format)
+        }
         cb()
       })
     })
@@ -132,6 +152,79 @@ tap("save-pixels saving a RGB jpeg", function(t) {
     }
   }
   compareImages(t, x, "jpeg", function() {
+    t.end()
+  })
+})
+
+tap("save-pixels saving an unanimated gif", function(t) {
+  var x = zeros([64, 64, 4])
+  
+  for(var i=0; i<32; ++i) {
+    for(var j=0; j<32; ++j) {
+      x.set(i, j, 0, 0)
+      x.set(i, j, 1, 0)
+      x.set(i, j, 2, 0)
+      x.set(i, j, 3, 255)
+      x.set(i+32, j, 0, 255)
+      x.set(i+32, j, 1, 255)
+      x.set(i+32, j, 2, 255)
+      x.set(i+32, j, 3, 255)
+      x.set(i, j+32, 0, 255)
+      x.set(i, j+32, 1, 255)
+      x.set(i, j+32, 2, 255)
+      x.set(i, j+32, 3, 255)
+      x.set(i+32, j+32, 0, 0)
+      x.set(i+32, j+32, 1, 0)
+      x.set(i+32, j+32, 2, 0)
+      x.set(i+32, j+32, 3, 255)
+    }
+  }
+  testArray(t, x, "gif", function() {
+    t.end()
+  })
+})
+
+tap("save-pixels saving an animated gif", function(t) {
+  var x = zeros([2, 64, 64, 4])
+  
+  for(var i=0; i<32; ++i) {
+    for(var j=0; j<32; ++j) {
+      x.set(0, i, j, 0, 0)
+      x.set(0, i, j, 1, 0)
+      x.set(0, i, j, 2, 0)
+      x.set(0, i, j, 3, 255)
+      x.set(0, i+32, j, 0, 255)
+      x.set(0, i+32, j, 1, 255)
+      x.set(0, i+32, j, 2, 255)
+      x.set(0, i+32, j, 3, 255)
+      x.set(0, i, j+32, 0, 255)
+      x.set(0, i, j+32, 1, 255)
+      x.set(0, i, j+32, 2, 255)
+      x.set(0, i, j+32, 3, 255)
+      x.set(0, i+32, j+32, 0, 0)
+      x.set(0, i+32, j+32, 1, 0)
+      x.set(0, i+32, j+32, 2, 0)
+      x.set(0, i+32, j+32, 3, 255)
+      
+      x.set(1, i, j, 0, 255)
+      x.set(1, i, j, 1, 255)
+      x.set(1, i, j, 2, 255)
+      x.set(1, i, j, 3, 255)
+      x.set(1, i+32, j, 0, 0)
+      x.set(1, i+32, j, 1, 0)
+      x.set(1, i+32, j, 2, 0)
+      x.set(1, i+32, j, 3, 255)
+      x.set(1, i, j+32, 0, 0)
+      x.set(1, i, j+32, 1, 0)
+      x.set(1, i, j+32, 2, 0)
+      x.set(1, i, j+32, 3, 255)
+      x.set(1, i+32, j+32, 0, 255)
+      x.set(1, i+32, j+32, 1, 255)
+      x.set(1, i+32, j+32, 2, 255)
+      x.set(1, i+32, j+32, 3, 255)
+    }
+  }
+  testArray(t, x, "gif", function() {
     t.end()
   })
 })


### PR DESCRIPTION
In order to support all basic image formats, we are adding support for `GIF`. This includes support for animated GIFs, meaning 4d arrays. I chose to use checkerboards for the patterns since GIFs have a limited color palette and we have already tested monochrome upcasting in other cases.

In this PR:
- Added test for unanimated/animated GIFs
- Added support for unanimated/animated GIFs
