### PR TITLE
Added support for quality for JPEG export

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Saves an ndarray as an image with the given format
 * `array` is an `ndarray` of pixels.  Assumes that shape is `[width, height, channels]`
 * `type` is the type of the image to save.  Currently supported formats:
 
+  + `"jpeg"`, `"jpg"` - Joint Photographic Experts Group format
+  + `"gif"` - Graphics Interchange Format
   + `"png"` - Portable Network Graphics format
   + `"canvas"` - A canvas element
 

--- a/save-pixels.js
+++ b/save-pixels.js
@@ -71,7 +71,8 @@ function haderror(err) {
   return result
 }
 
-module.exports = function savePixels(array, type) {
+module.exports = function savePixels(array, type, options) {
+  options = options || {}
   switch(type.toUpperCase()) {
     case "JPG":
     case ".JPG":
@@ -88,7 +89,7 @@ module.exports = function savePixels(array, type) {
         width: width,
         height: height
       }
-      var jpegImageData = jpegJs.encode(rawImageData)
+      var jpegImageData = jpegJs.encode(rawImageData, options.quality)
       return new ContentStream(jpegImageData.data)
 
     case "GIF":


### PR DESCRIPTION
**Depends on #14**

As discussed in #13, it would be nice to support setting quality for JPEG export. This PR implements support for receiving `options` like `quality`. In this PR:

- Added `options.quality` support for JPEG export
- Updated tests to be more granular in control (e.g. can compare 2 generated images)
- Added tests for `options.quality`
- Fixes #13 

**Missing:**

We haven't update the README with notes on `options`/`options.quality` since this is partially a proof of concept. However, if requested we can add that to this PR.