### PR TITLE
jpeg-js upgrade (and tap made dev dependency)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "get-pixels": "^3.0.1",
     "ndarray-scratch": "^1.1.1",
+    "tap": "^10.7.0",
     "tape": "^3.0.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "contentstream": "^1.0.0",
     "gif-encoder": "~0.4.1",
-    "jpeg-js": "0.0.4",
+    "jpeg-js": "^0.3.2",
     "ndarray": "^1.0.18",
     "ndarray-ops": "^1.2.2",
     "pngjs-nozlib": "^1.0.0",


### PR DESCRIPTION
Closes #23.

jpeg-js is upgraded to the latest released version (`^0.3.2`), which solves the issue of `ugilifyjs` failing on this library. It also brings some algorithm improvements.

I also made `tap` (`^10.7.0`) a dev dependency, so the tests can be run by a new contributor without installing an additional global.

### Tests
All pass!