### PR TITLE
chore: bump tap to 12.7.0, bump tape to 5.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "devDependencies": {
     "get-pixels": "^3.0.1",
     "ndarray-scratch": "^1.1.1",
-    "tap": "^10.7.0",
-    "tape": "^3.0.1"
+    "tap": "^12.7.0",
+    "tape": "^5.2.2"
   },
   "scripts": {
     "test": "tap test/*.js"


### PR DESCRIPTION
This fixes several vulnerabilities in dev dependencies. While tap 12.7.0 is not the newest available version of tap it seems to be the most compatible one. tap 15.0.x also checks coverage and fails, if less then 100 % is covered (which is the case). Therefore, it's only tap 12.7.0.