### PR TITLE
chore(deps): bump jpeg-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "contentstream": "^1.0.0",
     "gif-encoder": "~0.4.1",
-    "jpeg-js": "^0.3.2",
+    "jpeg-js": "^0.4.3",
     "ndarray": "^1.0.18",
     "ndarray-ops": "^1.2.2",
     "pngjs-nozlib": "^1.0.0",


### PR DESCRIPTION
According to https://github.com/scijs/save-pixels/pull/28#issuecomment-882414210 this PR bumps jpeg-js. save-pixels still works fine with newer version.

This could be published as bugfix (patch) update.